### PR TITLE
Remove fixed viewport dimensions from screenshot tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,9 +325,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1622,9 +1622,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-            "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+            "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
             "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0",

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -33,14 +33,12 @@ export const TOOLS: Tool[] = [
   },
   {
     name: "puppeteer_screenshot",
-    description: "Take a screenshot of the current page or a specific element",
+    description: "Take a screenshot of the current page or a specific element using the current browser viewport size",
     inputSchema: {
       type: "object",
       properties: {
         name: { type: "string", description: "Name for the screenshot" },
         selector: { type: "string", description: "CSS selector for element to screenshot" },
-        width: { type: "number", description: "Width in pixels (default: 800)" },
-        height: { type: "number", description: "Height in pixels (default: 600)" },
       },
       required: ["name"],
     },

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -101,10 +101,6 @@ export async function handleToolCall(
       }
 
     case "puppeteer_screenshot": {
-      const width = args.width ?? 800;
-      const height = args.height ?? 600;
-      await page.setViewport({ width, height });
-
       const screenshot = await (args.selector ?
         (await page.$(args.selector))?.screenshot({ encoding: "base64" }) :
         page.screenshot({ encoding: "base64", fullPage: false }));
@@ -126,7 +122,7 @@ export async function handleToolCall(
         content: [
           {
             type: "text",
-            text: `Screenshot '${args.name}' taken at ${width}x${height}`,
+            text: `Screenshot '${args.name}' taken`,
           } as TextContent,
           {
             type: "image",


### PR DESCRIPTION
The screenshot functionality now uses the current browser viewport size instead of forcing a fixed 800x600 resolution. This allows for more flexible screenshot capture that respects the user's current browser settings and provides more accurate visual representation.

#snapshot